### PR TITLE
Implement backward pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # flash-attention-minimal
-A minimal re-implementation of Flash Attention with CUDA and PyTorch. 
+
+A minimal re-implementation of Flash Attention with CUDA and PyTorch.
 The official [implementation](https://github.com/Dao-AILab/flash-attention) can be quite daunting for a CUDA beginner
 (like myself), so this repo tries to be small and educational.
 
@@ -7,43 +8,66 @@ The official [implementation](https://github.com/Dao-AILab/flash-attention) can 
 * The variable names follow the notations from the original [paper](https://arxiv.org/abs/2205.14135).
 
 ## Usage
+
 ### Prerequisite
+
 * PyTorch (with CUDA)
 * `Ninja` for loading in C++
 
 ### Benchmark
+
 Compare the wall-clock time between manual attention and minimal flash attention:
-```
+
+```bash
 python bench.py
 ```
 
-Sample output on a [T4](https://aws.amazon.com/ec2/instance-types/g4/):
+Sample output on a [T4](https://aws.amazon.com/ec2/instance-types/g4/) for the forward pass (Br = Bc = 32):
+
 ```
-=== profiling manual attention ===
+=== profiling manual attention (forward pass) ===
 ...
 Self CPU time total: 52.389ms
 Self CUDA time total: 52.545ms
 
-=== profiling minimal flash attention === 
-...  
+=== profiling minimal flash attention (forward pass) === 
+...
 Self CPU time total: 11.452ms
 Self CUDA time total: 3.908ms
 ```
-Speed-up achieved! 
+
+That's a 13x speedup!
+
+Sample output on an RTX 3060 for the backward pass (Br = Bc = 16):
+
+```
+=== profiling manual attention (backward pass) ===
+...
+Self CPU time total: 11.139ms
+Self CUDA time total: 1.721ms
+
+=== profiling minimal flash attention (backward pass) === 
+...
+Self CPU time total: 31.466ms
+Self CUDA time total: 629.000us
+```
+
+That's a 2x speedup! Note though that we've only tested this on an RTX 3060 which has a smaller SRAM than the T4
+(hence the reduction of block size from 32 to 16). The speedup might be different on a T4.
 
 ### I don't have a GPU
+
 Try out this [online colab demo](https://colab.research.google.com/gist/tspeterkim/143bc7be7a845656817cf94c5228598e/demo-flash-attention-minimal.ipynb).
 
 ## Caveats
-* No backward pass! To be honest, I found it a lot more complex than the forward pass, which was enough to show the
-use of shared memory to avoid large N^2 read/writes.
+
 * In the inner loop, I assign each thread to a row of the output matrix. This differs from the original implementation.
-* This thread-per-row simplification makes the matrix multiplications very slow. This is probably why for longer 
+* This thread-per-row simplification makes the matrix multiplications very slow. This is probably why for longer
 sequences and larger block sizes, this gets slower than the manual implementation.
 * Q,K,Vs are in float32, unlike the original implementation which uses float16.
 * The block size is [fixed](https://github.com/tspeterkim/flash-attention-minimal/blob/9b7ca8ef4e6afdbfeb149a9cd488c8dea9af9ad6/flash.cu#L85) at compile time to 32.
 
 ## Todos
-- [ ] Add backward pass
-- [ ] Speed up matmults
-- [ ] Dynamically set block size
+
+* [ ] Speed up matmults
+* [ ] Dynamically set block size

--- a/bench.py
+++ b/bench.py
@@ -13,11 +13,13 @@ n_head = 12
 seq_len = 64
 head_embd = 64
 
-q = torch.randn(batch_size, n_head, seq_len, head_embd).cuda()
-k = torch.randn(batch_size, n_head, seq_len, head_embd).cuda()
-v = torch.randn(batch_size, n_head, seq_len, head_embd).cuda()
+q = torch.randn(batch_size, n_head, seq_len, head_embd, requires_grad=True).cuda()
+k = torch.randn(batch_size, n_head, seq_len, head_embd, requires_grad=True).cuda()
+v = torch.randn(batch_size, n_head, seq_len, head_embd, requires_grad=True).cuda()
 
-print('=== profiling manual attention ===')
+print('====== profiling forward pass ======')
+
+print('=== profiling manual attention (forward pass) ===')
 
 # Our minimal flash attention aims to be faster than this by avoiding HBM read/writes of N^2 matrices.
 def manual_attn(q, k, v):
@@ -30,10 +32,42 @@ with torch.autograd.profiler.profile(use_cuda=True) as prof:
     manual_result = manual_attn(q, k, v)
 print(prof.key_averages().table(sort_by='cuda_time_total', row_limit=10))
 
-print('=== profiling minimal flash attention === ')
+print('=== profiling minimal flash attention (forward pass) === ')
 
-with torch.autograd.profiler.profile(use_cuda=True) as prof:
-    minimal_result = minimal_attn.forward(q, k, v)
+with (
+    torch.autograd.profiler.profile(use_cuda=True) as prof,
+    torch.no_grad(),
+):
+    minimal_result, l, m = minimal_attn.forward(q, k, v)
 print(prof.key_averages().table(sort_by='cuda_time_total', row_limit=10))
 
 print('attn values sanity check:', torch.allclose(minimal_result, manual_result, rtol=0, atol=1e-02))
+
+print("\n\n\n")
+print('====== profiling backward pass ======')
+
+print('=== profiling manual attention (backward pass) ===')
+
+y_grad = torch.ones_like(minimal_result)
+
+def manual_attn_backward(q, k, v, y, y_grad):
+    return torch.autograd.grad([y], [q, k, v], grad_outputs=[y_grad])
+
+with torch.autograd.profiler.profile(use_cuda=True) as prof:
+    manual_grad_q, manual_grad_k, manual_grad_v = manual_attn_backward(
+        q, k, v, manual_result, y_grad
+    )
+print(prof.key_averages().table(sort_by='cuda_time_total', row_limit=10))
+
+print('=== profiling minimal flash attention (backward pass) === ')
+
+with (
+    torch.autograd.profiler.profile(use_cuda=True) as prof,
+    torch.no_grad(),
+):
+    minimal_grad_q, minimal_grad_k, minimal_grad_v = minimal_attn.backward(q, k, v, minimal_result, y_grad, l, m)
+print(prof.key_averages().table(sort_by='cuda_time_total', row_limit=10))
+
+print('q grad sanity check:', torch.allclose(manual_grad_q, minimal_grad_q, rtol=0, atol=1e-02))
+print('k grad sanity check:', torch.allclose(manual_grad_k, minimal_grad_k, rtol=0, atol=1e-02))
+print('v grad sanity check:', torch.allclose(manual_grad_v, minimal_grad_v, rtol=0, atol=1e-02))

--- a/flash.cu
+++ b/flash.cu
@@ -3,9 +3,21 @@
 #include <cuda_runtime.h>
 
 __global__
-void forward_kernel(const float* Q, const float* K, const float* V, const int N, const int d,
-                    const int Tc, const int Tr, const int Bc, const int Br, const float softmax_scale,
-                    float* l, float *m, float* O) {
+void forward_kernel(
+    const float* Q,
+    const float* K,
+    const float* V,
+    const int N,
+    const int d,
+    const int Tc,
+    const int Tr,
+    const int Bc,
+    const int Br,
+    const float softmax_scale,
+    float* l,
+    float* m,
+    float* O
+) {
     int tx = threadIdx.x;
     int bx = blockIdx.x; int by = blockIdx.y;  // batch and head index
 
@@ -40,6 +52,8 @@ void forward_kernel(const float* Q, const float* K, const float* V, const int N,
             float row_l_prev = l[lm_offset + (Br * i) + tx];
 
             // S = QK^T, row_m = rowmax(S)
+            // S[tx][y] = Sum_{x = 0}^{d-1} {Qi[tx][x] * Kj[y][x]}
+            // row_m = Max_{y = 0}^{Bc-1} S[tx][y]
             float row_m = -INFINITY;
             for (int y = 0; y < Bc; y++) {
                 float sum = 0;
@@ -54,6 +68,7 @@ void forward_kernel(const float* Q, const float* K, const float* V, const int N,
             }
 
             // P = exp(S - row_m), row_l = rowsum(P)
+            // P[tx][y] = exp(S[tx][y] - row_m)
             float row_l = 0;
             for (int y = 0; y < Bc; y++) {
                 S[(Bc * tx) + y] = __expf(S[(Bc * tx) + y] - row_m);
@@ -81,7 +96,165 @@ void forward_kernel(const float* Q, const float* K, const float* V, const int N,
     }
 }
 
-torch::Tensor forward(torch::Tensor Q, torch::Tensor K, torch::Tensor V) {
+__global__
+void backward_kernel(
+    const float* Q,
+    const float* K,
+    const float* V,
+    const float* O,
+    const float* dO,
+    const float* l,
+    const float* m,
+    const int N,
+    const int d,
+    const int Tc,
+    const int Tr,
+    const int Bc,
+    const int Br,
+    const float softmax_scale,
+    float* dQ,
+    float* dK,
+    float* dV
+) {
+    int tx = threadIdx.x;
+    int bx = blockIdx.x; int by = blockIdx.y;  // batch and head index
+
+    // Offset into Q,K,V,O,l,m - different for each batch and head
+    int qkv_offset = (bx * gridDim.y * N * d) + (by * N * d);  // gridDim.y = nh
+    int lm_offset = (bx * gridDim.y * N) + (by * N);  // offset for l and m
+
+    // Define SRAM for Q,K,V,S
+    extern __shared__ float sram[];
+    int col_tile_size = Bc * d;  // size of Kj, Vj
+    int row_tile_size = Br * d;  // size of Qi
+    float* Kj = sram;
+    float* Vj = &sram[col_tile_size];
+
+    float* dKj = &sram[col_tile_size * 2];
+    float* dVj = &sram[col_tile_size * 3];
+
+    float* Qi = &sram[col_tile_size * 4];
+    float* Oi = &sram[col_tile_size * 4 + row_tile_size];
+    float* dOi = &sram[col_tile_size * 4 + row_tile_size * 2];
+
+    // We also use S for P. Likewise, we use dS for dP.
+    // We can reuse the same memory because we don't need S and P at the same time.
+    // We also don't need dS and dP at the same time.
+    float* S = &sram[col_tile_size * 4 + row_tile_size * 3];
+    float* dS = &sram[col_tile_size * 4 + row_tile_size * 3 + Bc * Br];
+
+    for (int j = 0; j < Tc; j++) {
+
+        // Load Kj, Vj to SRAM
+        for (int x = 0; x < d; x++) {
+            Kj[(tx * d) + x] = K[qkv_offset + (col_tile_size * j) + (tx * d) + x];
+            Vj[(tx * d) + x] = V[qkv_offset + (col_tile_size * j) + (tx * d) + x];
+        }
+
+        // Initialize dKj, dVj to 0
+        for (int x = 0; x < d; x++) {
+            dKj[(tx * d) + x] = 0;
+            dVj[(tx * d) + x] = 0;
+        }
+
+        __syncthreads();  // such that the inner loop can use the correct Kj, Vj
+        for (int i = 0; i < Tr; i++)  {
+
+            // Load Qi, Oi, dOi, dQi, li, mi to SRAM
+            // Also load l, m to registers
+            for (int x = 0; x < d; x++) {
+                Qi[(tx * d) + x] = Q[qkv_offset + (row_tile_size * i) + (tx * d) + x];
+                Oi[(tx * d) + x] = O[qkv_offset + (row_tile_size * i) + (tx * d) + x];
+                dOi[(tx * d) + x] = dO[qkv_offset + (row_tile_size * i) + (tx * d) + x];
+            }
+            float m_curr = m[lm_offset + (Br * i) + tx];
+            float l_curr = l[lm_offset + (Br * i) + tx];
+
+            // Sij = softmax_scale * QiKj^T
+            // Sij[tx][y] = softmax_scale * Sum_{y = 0}^{Bc-1} Qi[tx][x] * Kj[y][x]
+            for (int y = 0; y < Bc; y++) {
+                float sum = 0;
+                for (int x = 0; x < d; x++) {
+                    sum += Qi[(tx * d) + x] * Kj[(y * d) + x];
+                }
+                sum *= softmax_scale;
+                S[(Bc * tx) + y] = sum;
+            }
+
+            // Pij = diag(li)^-1 * exp(Sij - mi)
+            // Pij[tx][y] = (1 / li[tx]) * exp(Sij[tx][y] - mi[tx])
+            for (int y = 0; y < Bc; y++) {
+                S[(Bc * tx) + y] = (1 / l_curr) * __expf(S[(Bc * tx) + y] - m_curr);
+            }
+
+            // dVj <- dVj + Pij^T * dOi
+            // dVj[tx][x] = dVj[tx][x] + Sum_{y = 0}^{Br-1} Pij[y][tx] * dOi[tx][x]
+            for (int x = 0; x < d; x++) {
+                float sum = 0;
+                for (int y = 0; y < Br; y++) {
+                    sum += S[(Bc * y) + tx] * dOi[(tx * d) + x];
+                }
+                atomicAdd(&dVj[(tx * d) + x], sum);
+            }
+
+            // dPij <- dOi * Vj^T
+            // dPij[tx][y] = Sum_{x = 0}^{d-1} dOi[tx][x] * Vj[y][x]
+            for (int y = 0; y < Bc; y++) {
+                float sum = 0;
+                for (int x = 0; x < d; x++) {
+                    sum += dOi[(tx * d) + x] * Vj[(y * d) + x];
+                }
+                dS[(Bc * tx) + y] = sum;
+            }
+
+            // Di <- rowsum(dOi * Oi)  (pointwise multiply)
+            // Di[tx] = Sum_{x = 0}^{d-1} dOi[tx][x] * Oi[tx][x]
+            float Di = 0;
+            for (int x = 0; x < d; x++) {
+                Di += dOi[(tx * d) + x] * Oi[(tx * d) + x];
+            }
+
+            // dSij <- Pij * (dPij - Di)
+            // dSij[tx][y] = Pij[tx][y] * (dPij[tx][y] - Di[tx])
+            for (int y = 0; y < Bc; ++y) {
+                dS[(Bc * tx) + y] = S[(Bc * tx) + y] * (dS[(Bc * tx) + y] - Di);
+            }
+
+            // dQi <- dQi + softmax_scale * dSijKj
+            // dQ[tx][x] = dQ[tx][x] + softmax_scale * Sum_{y = 0}^{Bc-1} dSij[tx][y] * Kj[y][x]
+            for (int x = 0; x < d; x++) {
+                float sum = 0;
+                for (int y = 0; y < Bc; y++) {
+                    sum += dS[(Bc * tx) + y] * Kj[(y * d) + x];
+                }
+                sum *= softmax_scale;
+                atomicAdd(&dQ[qkv_offset + (row_tile_size * i) + (tx * d) + x], sum);
+            }
+
+            // dKj <- dKj + softmax_scale * dSij^TQi
+            // dKj[tx][x] = dKj[tx][x] + softmax_scale * Sum_{y = 0}^{Br-1} dSij[y][tx] * Qi[y][x]
+            for (int x = 0; x < d; x++) {
+                float sum = 0;
+                for (int y = 0; y < Br; y++) {
+                    sum += dS[(Bc * y) + tx] * Qi[(y * d) + x];
+                }
+                sum *= softmax_scale;
+                atomicAdd(&dKj[(tx * d) + x], sum);
+            }
+        }
+        __syncthreads();  // otherwise, thread can use the wrong Kj, Vj in inner loop
+
+        // Upload Kj, Vj to HRAM
+        for (int x = 0; x < d; x++) {
+            dK[qkv_offset + (row_tile_size * j) + (tx * d) + x] = dKj[(tx * d) + x];
+            dV[qkv_offset + (row_tile_size * j) + (tx * d) + x] = dVj[(tx * d) + x];
+        }
+
+        __syncthreads();  // otherwise, thread can use the wrong Kj, Vj in inner loop
+    }
+}
+
+std::vector<torch::Tensor> forward(torch::Tensor Q, torch::Tensor K, torch::Tensor V) {
     // TODO: determine Bc, Br dynamically
     const int Bc = 32; const int Br = 32;
 
@@ -99,18 +272,69 @@ torch::Tensor forward(torch::Tensor Q, torch::Tensor K, torch::Tensor V) {
     l = l.to(device); m = m.to(device);
 
     // Calculate SRAM size needed per block
-    const int sram_size = (3 * Bc * d * sizeof(float)) + (Bc * Br * sizeof(float));
+    int col_tile_size = Bc * d;  // size of Kj, Vj
+    int row_tile_size = Br * d;  // size of Qi
+    const int sram_size =
+        (2 * col_tile_size * sizeof(float))  // SRAM size for Kj, Vj
+        + (row_tile_size * sizeof(float))  // SRAM size for Qi
+        + (Bc * Br * sizeof(float));  // SRAM size for S
     int max_sram_size;
     cudaDeviceGetAttribute(&max_sram_size, cudaDevAttrMaxSharedMemoryPerBlock, 0);
-    printf("Max shared memory: %d, requested shared memory: %d \\n", max_sram_size, sram_size);
+    printf("Max shared memory: %d, requested shared memory: %d \n", max_sram_size, sram_size);
 
     dim3 grid_dim(B, nh);  // batch_size x num_heads
-    dim3 block_dim(Bc);  // Bc threads per block
+    dim3 block_dim(Br);  // Br threads per block
 
     forward_kernel<<<grid_dim, block_dim, sram_size>>>(
         Q.data_ptr<float>(), K.data_ptr<float>(), V.data_ptr<float>(),
         N, d, Tc, Tr, Bc, Br, softmax_scale,
         l.data_ptr<float>(), m.data_ptr<float>(), O.data_ptr<float>()
     );
-    return O;
+    return {O, l, m};
+}
+
+std::vector<torch::Tensor> backward(
+    torch::Tensor Q,
+    torch::Tensor K,
+    torch::Tensor V,
+    torch::Tensor O,
+    torch::Tensor dO,
+    torch::Tensor l,
+    torch::Tensor m
+) {
+    // TODO: determine Bc, Br dynamically
+    const int Bc = 16; const int Br = 16;
+
+    const int B = Q.size(0); const int nh = Q.size(1);
+    const int N = Q.size(2); const int d = Q.size(3);
+
+    const int Tc = ceil((float) N / Bc); const int Tr = ceil((float) N / Br);
+    const float softmax_scale = 1.0 / sqrt(d);
+
+    auto dQ = torch::zeros_like(Q);
+    auto dK = torch::zeros_like(K);
+    auto dV = torch::zeros_like(V);
+
+    // Calculate SRAM size needed per block
+    int col_tile_size = Bc * d;  // size of Kj, Vj
+    int row_tile_size = Br * d;  // size of Qi, Oi, dOi
+    const int sram_size =
+        (4 * col_tile_size * sizeof(float))  // SRAM size for Kj, Vj, dKj, dVj
+        + (3 * row_tile_size * sizeof(float))  // SRAM size for Qi, Oi, dOi
+        + (2 * Br * Bc * sizeof(float));  // SRAM size for S, dS
+    int max_sram_size;
+    cudaDeviceGetAttribute(&max_sram_size, cudaDevAttrMaxSharedMemoryPerBlock, 0);
+    printf("Max shared memory: %d, requested shared memory: %d \n", max_sram_size, sram_size);
+
+    dim3 grid_dim(B, nh);  // batch_size x num_heads
+    dim3 block_dim(Br);  // Bc threads per block
+
+    backward_kernel<<<grid_dim, block_dim, sram_size>>>(
+        Q.data_ptr<float>(), K.data_ptr<float>(), V.data_ptr<float>(),
+        O.data_ptr<float>(), dO.data_ptr<float>(),
+        l.data_ptr<float>(), m.data_ptr<float>(),
+        N, d, Tc, Tr, Bc, Br, softmax_scale,
+        dQ.data_ptr<float>(), dK.data_ptr<float>(), dV.data_ptr<float>()
+    );
+    return {dQ, dK, dV};
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,17 @@
 #include <torch/extension.h>
 
-torch::Tensor forward(torch::Tensor q, torch::Tensor k, torch::Tensor v);
+std::vector<torch::Tensor> forward(torch::Tensor Q, torch::Tensor K, torch::Tensor V);
+std::vector<torch::Tensor> backward(
+    torch::Tensor Q,
+    torch::Tensor K,
+    torch::Tensor V,
+    torch::Tensor O,
+    torch::Tensor dO,
+    torch::Tensor l,
+    torch::Tensor m
+);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("forward", torch::wrap_pybind_function(forward), "forward");
+    m.def("backward", torch::wrap_pybind_function(backward), "backward");
 }


### PR DESCRIPTION
# Description

This PR implements a minimal backward pass for flash attention.

I got these results on my RTX 2060

```
=== profiling manual attention (backward pass) ===
...
Self CPU time total: 11.139ms
Self CUDA time total: 1.721ms
=== profiling minimal flash attention (backward pass) === 
...
Self CPU time total: 31.466ms
Self CUDA time total: 629.000us
```

2x speedup

Tho my GPU can only handle size 16 blocks (vs. size 32 blocks for T4)